### PR TITLE
Enable autoscale.

### DIFF
--- a/aea_projection.py
+++ b/aea_projection.py
@@ -78,9 +78,12 @@ class SkymapperAxes(Axes):
         self.yaxis.set_ticks_position('none')
 
         self.set_center(None, None)
-        self.set_xlim(0, 360)
-        self.set_ylim(-90, 90)
-        self.set_autoscale_on(False)
+
+        # FIXME: probabaly want to override autoscale_view
+        # to properly handle wrapping introduced by margin
+        # and properlty wrap data. 
+        # It doesn't make sense to have xwidth > 360. 
+        self._tight = True
 
     def _set_lim_and_transforms(self):
         """


### PR DESCRIPTION
Currently we avoid margins by setting self._tight. We really
should have overriden autoscale_view to properly handle xlim > 360.

But what is the correct behavior then?

This allows the following minimal example to produce a reasonable map, without setting limits or center.

![index](https://cloud.githubusercontent.com/assets/138060/14406791/e99a3c4c-fe67-11e5-9caa-f9c884d35514.png)

```
import matplotlib.pyplot as plt
import numpy as np
import aea_projection

fig = plt.figure(figsize=(6, 4))
ra = np.random.uniform(size=10000, low=0, high=360)
dec = np.random.uniform(size=10000, low=-30, high=50)
ax = fig.add_subplot(111,  projection="aea")
ax.plot(ra[::100], dec[::100], 'x')
ax.histmap(ra, dec, nside=8)
```
